### PR TITLE
feat: refactor class to follow OCP

### DIFF
--- a/SOLID/1.2-OCP/main.py
+++ b/SOLID/1.2-OCP/main.py
@@ -1,9 +1,25 @@
-class NotificationService:
-    def send_notification(self, method: str, message: str):
-        if method == "email":
-            self.send_email(message)
-        else:
-            raise ValueError(f"Unsupported notification method: {method}")
+from abc import ABC, abstractmethod
 
-    def send_email(self, message: str):
+#Abstract class for notification methods
+class NotificationInterface(ABC):
+    @abstractmethod
+    def send_notification(self, message: str):
+        pass
+
+#Class for email notifications
+class EmailNotification(NotificationInterface):
+    def send(self, message: str):
         print(f"Sending email with message: {message}")
+
+#Class for SMS notifications
+class SMSNotification(NotificationInterface):
+    def send(self, message: str):
+        print(f"Sending SMS with message: {message}")
+
+#Service for sending notifications
+class NotificationService:
+    def __init__(self, notification: NotificationInterface):
+        self.notification = notification
+
+    def send_notification(self, message: str):
+        self.notification.send(message)


### PR DESCRIPTION
An interface called NotificationInterface is implemented that all notification classes must follow, allowing each method to implement its own logic without affecting the overall definition.
New classes that implement notifications can be added without modifying existing code.