### PR TITLE
feat: refactor class to follow DIP

### DIFF
--- a/SOLID/1.5-DIP/main.py
+++ b/SOLID/1.5-DIP/main.py
@@ -1,20 +1,28 @@
-class CreditCardPayment:
-    def process_credit_card(self, amount: float, card_number: str):
-        print(f"Processing credit card payment of ${amount} with card number {card_number}")
+from abc import ABC, abstractmethod
 
-class PayPalPayment:
-    def process_paypal(self, amount: float, email: str):
-        print(f"Processing PayPal payment of ${amount} with email {email}")
+class PaymentInterface(ABC):
+    @abstractmethod
+    def process_payment(self, amount: float):
+        pass
+
+class CreditCardPayment(PaymentInterface):
+    def __init__(self, card_number: str) -> None:
+        self.card_number = card_number
+
+    def process_payment(self, amount: float):
+        print(f"Processing credit card payment of ${amount} with card number {self.card_number}")
+
+class PayPalPayment(PaymentInterface):
+    def __init__(self, email: str) -> None:
+        self.email = email
+
+    def process_payment(self, amount: float):
+        print(f"Processing PayPal payment of ${amount} with email {self.email}")
 
 class PaymentProcessor:
-    def __init__(self):
-        self.credit_card_payment = CreditCardPayment()
-        self.paypal_payment = PayPalPayment()
+    def __init__(self, payment_method: PaymentInterface) -> None:
+        self.payment_method = payment_method
 
-    def process_payment(self, method: str, amount: float, details: str):
-        if method == "credit_card":
-            self.credit_card_payment.process_credit_card(amount, details)
-        elif method == "paypal":
-            self.paypal_payment.process_paypal(amount, details)
-        else:
-            raise ValueError("Unsupported payment method")
+    def process_payment(self, amount: float):
+        self.payment_method.process_payment(amount)
+


### PR DESCRIPTION
This refactoring complies with the DIP principle because:

- An abstract interface PaymentInterface is defined that allows high-level classes to depend on that abstraction and not on concrete implementations
- No low-level class depends on a high-level class